### PR TITLE
lib: add rule to check for zero value unit identifiers

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@
  * Module dependencies
  */
 
-var validateCustomProperties = require('./lib/validate-properties');
-var validateSelectors = require('./lib/validate-selectors');
-var validateRules = require('./lib/validate-rules');
-var validateZIndices = require('./lib/validate-z-indices');
 var validateColors = require('./lib/validate-colors');
+var validateCustomProperties = require('./lib/validate-properties');
+var validateRules = require('./lib/validate-rules');
+var validateSelectors = require('./lib/validate-selectors');
+var validateUnitIdentifiers = require('./lib/validate-unit-identifiers');
+var validateZIndices = require('./lib/validate-z-indices');
 
 /**
  * Module exports
@@ -106,6 +107,7 @@ function runBaseTests(rules) {
   validateRules(rules);
   validateZIndices(rules);
   validateColors(rules);
+  validateUnitIdentifiers(rules);
 }
 
 /**

--- a/lib/validate-unit-identifiers.js
+++ b/lib/validate-unit-identifiers.js
@@ -21,13 +21,38 @@ function validateUnitIdentifiers(rules) {
       var pos = declaration.position.start;
       var property = declaration.property;
 
-      if (parseInt(val) === 0 && val.length !== 1) {
-        var unitIdentifier = /0(.*)/g.exec(val)[1];
-        throw new Error(
-          'Invalid zero value unit identifier "' + unitIdentifier + '" near line ' +
-            pos.line + ':' + pos.column + '. Use "' + property + ': 0" instead.'
-        );
-      }
+      var openParen = false;
+      var group = '';
+      var groups = [];
+      val.split('').forEach(function(c) {
+        if (c === '(') {
+          openParen = true;
+        }
+        if (c === ')') {
+          openParen = false;
+        }
+        if (c === ' ' && !openParen) {
+          groups.push(group);
+          group = '';
+          return;
+        }
+        group += c;
+      });
+      groups.push(group);
+
+      groups.forEach(function(v) {
+        if (v.indexOf('(') > -1 || v.indexOf(')') > -1) {
+          return;
+        }
+
+        if (parseInt(v) === 0 && v.length !== 1) {
+          var unitIdentifier = /0(.*)/g.exec(v)[1];
+          throw new Error(
+            'Invalid zero value unit identifier "' + unitIdentifier + '" near line ' +
+              pos.line + ':' + pos.column + '. Use "' + property + ': 0" instead.'
+          );
+        }
+      });
     });
   });
 }

--- a/lib/validate-unit-identifiers.js
+++ b/lib/validate-unit-identifiers.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Module exports
+ */
+
+module.exports = validateUnitIdentifiers;
+
+/**
+ * @param {Array} rules
+ */
+
+function validateUnitIdentifiers(rules) {
+  rules.forEach(function (rule) {
+    rule.declarations.forEach(function (declaration) {
+      if (declaration.type !== 'declaration') {
+        return;
+      }
+
+      var val = declaration.value;
+      var pos = declaration.position.start;
+      var property = declaration.property;
+
+      if (parseInt(val) === 0 && val.length !== 1) {
+        var unitIdentifier = /0(.*)/g.exec(val)[1];
+        throw new Error(
+          'Invalid zero value unit identifier "' + unitIdentifier + '" near line ' +
+            pos.line + ':' + pos.column + '. Use "' + property + ': 0" instead.'
+        );
+      }
+    });
+  });
+}

--- a/test/fixtures/invalid-multi-unit-identifiers.css
+++ b/test/fixtures/invalid-multi-unit-identifiers.css
@@ -1,0 +1,6 @@
+/** @define InvalidMultiUnitIdentifier; use strict */
+
+.InvalidMultiUnitIdentifier {
+  box-shadow: inset 0px 1px 2px rgba(var(--color-black), 0);
+}
+

--- a/test/fixtures/invalid-single-unit-identifiers.css
+++ b/test/fixtures/invalid-single-unit-identifiers.css
@@ -1,0 +1,5 @@
+/** @define InvalidSingleUnitIdentifier; use strict */
+
+.InvalidSingleUnitIdentifier {
+  height: 0em;
+}

--- a/test/fixtures/invalid-unit-identifiers.css
+++ b/test/fixtures/invalid-unit-identifiers.css
@@ -1,0 +1,6 @@
+/** @define InvalidUnitIdentifier; use strict */
+
+.Foo {
+  height: 0px;
+}
+

--- a/test/fixtures/invalid-unit-identifiers.css
+++ b/test/fixtures/invalid-unit-identifiers.css
@@ -1,6 +1,0 @@
-/** @define InvalidUnitIdentifier; use strict */
-
-.Foo {
-  height: 0px;
-}
-

--- a/test/fixtures/valid-unit-identifiers.css
+++ b/test/fixtures/valid-unit-identifiers.css
@@ -1,0 +1,6 @@
+/** @define ValidUnitIdentifiers */
+
+.ValidUnitIdentifiers {
+  height: 20px;
+  line-height: 100em;
+}

--- a/test/fixtures/valid-unit-identifiers.css
+++ b/test/fixtures/valid-unit-identifiers.css
@@ -3,4 +3,7 @@
 .ValidUnitIdentifiers {
   height: 20px;
   line-height: 100em;
+  box-shadow: inset 0 1px 2px rgba(var(--color-black), 0);
+  margin: 0 1px 1px 1px;
+  width: calc(var(--width-box) + 0);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -90,4 +90,11 @@ describe('linting', function () {
       assertSuccess('valid-colors');
     });
   });
+
+  describe('unit identifiers', function() {
+    it('must use unit identifiers only when necessary', function () {
+      assertFailure('invalid-unit-identifiers', /Invalid zero value/);
+      assertSuccess('valid-unit-identifiers');
+    });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -93,7 +93,8 @@ describe('linting', function () {
 
   describe('unit identifiers', function() {
     it('must use unit identifiers only when necessary', function () {
-      assertFailure('invalid-unit-identifiers', /Invalid zero value/);
+      assertFailure('invalid-single-unit-identifiers', /Invalid zero value/);
+      assertFailure('invalid-multi-unit-identifiers', /Invalid zero value/);
       assertSuccess('valid-unit-identifiers');
     });
   });


### PR DESCRIPTION
This checks for `height: 0px` and suggests to use `height: 0` instead. There's probably a property/value combo where this might make sense so happy to be as defensive as possible here (blanking on what those combinations would be ATM...).

r? @michelle 
